### PR TITLE
System.NullReferenceException: Object reference not set to an instance of an object: see description

### DIFF
--- a/CheatSheet.cs
+++ b/CheatSheet.cs
@@ -116,8 +116,14 @@ namespace CheatSheet
 		}
 
 		internal static string CSText(string category, string key)
-		{
-			return translations[$"Mods.CheatSheet.{category}.{key}"].GetTranslation(Language.ActiveCulture);
+		{	
+			category = category != null ? category : String.Empty;
+			key = key != null ? key : String.Empty; 
+
+			string returnTrans = translations[$"Mods.CheatSheet.{category}.{key}"].GetTranslation(Language.ActiveCulture); 
+			
+			return returnTrans != null ? returnTrans : String.Empty;
+			
 			// This isn't good until after load....can revert after fixing static initializers for string[]
 			// return Language.GetTextValue($"Mods.CheatSheet.{category}.{key}");
 		}


### PR DESCRIPTION
```
[22:37:35] [1/INFO] [tML]: Unloading mods
[22:37:35] [1/FATAL] [tML]: One or more errors occured while unloading and tModLoader must be restarted to prevent further issues.
CheatSheet was unable to unload properly. Modders must use defensive programming to ensure unloading completes regardless of any errors during loading.
System.TypeInitializationException: The type initializer for 'CheatSheet.Menus.ItemBrowser' threw an exception. ---> System.NullReferenceException: Object reference not set to an instance of an object
  at CheatSheet.CheatSheet.CSText (String category, String key) [0x00011] in data-0x1640cf000 
  at CheatSheet.Menus.ItemBrowser.CSText (String key, String category) [0x00000] in data-0x1640cf000 
  at CheatSheet.Menus.ItemBrowser..cctor () [0x00000] in data-0x1640cf000 
   --- End of inner exception stack trace ---
  at Terraria.ModLoader.Mod.UnloadContent () [0x00000] in tModLoader.exe 
  at Terraria.ModLoader.ModContent.UnloadModContent () [0x0001f] in tModLoader.exe 
```

A gross fix, but unloading cheat sheet then crashing is annoying