### PR TITLE
Bugfix Paint UI interface stops hotbar scrollwheel

### DIFF
--- a/Menus/PaintToolsUI.cs
+++ b/Menus/PaintToolsUI.cs
@@ -396,6 +396,7 @@ namespace CheatSheet.Menus
 		private void bClose_onLeftClick(object sender, EventArgs e)
 		{
 			Hide();
+			mod.paintToolsHotbar.Hide();
 			mod.hotbar.DisableAllWindows();
 		}
 	}


### PR DESCRIPTION
This change fixes the following use case:

If I press on the Paint Tool or Eyedropper tool on the Paint Toolbar
When I close the schematics window by pressing the X button on the top right
Then the scrollwheel will no longer function on the main UI until I re-open the Paint UI

**Changelog:**
- Add Hide() method call to close of Paint UI window